### PR TITLE
Switch backend Dockerfile to multi-stage build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,10 @@
-FROM python:3.11-slim
+FROM python:3.11-slim AS builder
+
 WORKDIR /app
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -13,7 +16,35 @@ RUN apt-get update \
         libffi-dev \
         shared-mime-info \
     && rm -rf /var/lib/apt/lists/*
-COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY requirements.txt ./requirements.txt
+
+RUN pip wheel --no-cache-dir --no-deps -r requirements.txt -w /wheels
+
+FROM python:3.11-slim AS runtime
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libcairo2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libgdk-pixbuf-2.0-0 \
+        shared-mime-info \
+        libpq5 \
+        libffi8 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./requirements.txt
+COPY --from=builder /wheels /wheels
+
+RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.txt \
+    && rm -rf /wheels /root/.cache/pip
+
 COPY . /app
+
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- convert the backend Dockerfile to a multi-stage build that precompiles requirements into wheels
- install runtime dependencies from the built wheels without caching artifacts to keep the image slim

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de4ea1f1ec8320bbd0336f10b87467