### PR TITLE
Allow backend wheel builds to resolve dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 
 COPY requirements.txt ./requirements.txt
 
-RUN pip wheel --no-cache-dir --no-deps -r requirements.txt -w /wheels
+RUN pip wheel --no-cache-dir -r requirements.txt -w /wheels
 
 FROM python:3.11-slim AS runtime
 


### PR DESCRIPTION
## Summary
- allow the builder-stage `pip wheel` command to download dependencies when creating local wheels

## Testing
- docker build -t syte-backend-test backend *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de50140bb0832089f809127840a4bc