### PR TITLE
Fix SlowAPI limiter configuration

### DIFF
--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -4,4 +4,8 @@ from slowapi.util import get_remote_address
 from settings import settings
 
 
-limiter = Limiter(key_func=get_remote_address, default_limits=[settings.RATE_LIMIT_DEFAULT])
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=[settings.RATE_LIMIT_DEFAULT],
+    storage_uri="redis://swimredis:6379/0",
+)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -58,7 +58,7 @@ def _client_ip(request: Request) -> str:
 
 
 @router.post("/login", response_model=Token)
-@limiter.limit("5/min")
+@limiter.limit("5/minute")
 def login_token(
     request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -138,7 +138,7 @@ def auth_register_form(request: Request):
     )
 
 @router.post("/auth/register")
-@limiter.limit("5/min")
+@limiter.limit("5/minute")
 def auth_register(
     request: Request,
     email: str = Form(...),
@@ -203,7 +203,7 @@ def auth_login_form(request: Request):
     return request.app.state.templates.TemplateResponse("auth_login.html", {"request": request})
 
 @router.post("/auth/login")
-@limiter.limit("5/min")
+@limiter.limit("5/minute")
 def auth_login(
     request: Request,
     email: str = Form(...),
@@ -231,7 +231,7 @@ def auth_logout(request: Request, db: Session = Depends(get_db)):
 
 
 @router.post("/refresh", response_model=Token)
-@limiter.limit("10/min")
+@limiter.limit("10/minute")
 def refresh_tokens(
     request: Request,
     payload: RefreshRequest,


### PR DESCRIPTION
## Summary
- configure the SlowAPI limiter to use Redis storage and the remote address key function
- normalize auth route rate limit declarations to use explicit interval names compatible with SlowAPI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deb9432cec8320b9ba7945d44d8a9a