### PR TITLE
Remove SlowAPI rate limiting hooks

### DIFF
--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,55 +1,14 @@
-from __future__ import annotations
+class _NoopLimiter:
+    """Fallback limiter that leaves endpoints unrestricted."""
 
-import re
-from collections.abc import Iterable
-from typing import Sequence
+    def limit(self, *args, **kwargs):  # noqa: D401 - simple passthrough decorator
+        """Return a decorator that does not alter the wrapped function."""
 
-from slowapi import Limiter
-from slowapi.util import get_remote_address
+        def decorator(func):
+            return func
 
-from settings import settings
-
-_GRANULARITY_ALIASES = {
-    "s": "second",
-    "sec": "second",
-    "second": "second",
-    "m": "minute",
-    "min": "minute",
-    "minute": "minute",
-    "h": "hour",
-    "hr": "hour",
-    "hour": "hour",
-    "d": "day",
-    "day": "day",
-}
-
-_LIMIT_PATTERN = re.compile(r"(?P<count>\d+)\s*/\s*(?P<granularity>[A-Za-z]+)")
+        return decorator
 
 
-def _normalize_limit_value(limit: str) -> str:
-    def _replace(match: re.Match[str]) -> str:
-        count = match.group("count")
-        granularity = match.group("granularity").lower()
-        normalized = _GRANULARITY_ALIASES.get(granularity, granularity)
-        return f"{count}/{normalized}"
+limiter = _NoopLimiter()
 
-    return _LIMIT_PATTERN.sub(_replace, limit)
-
-
-def _normalize_limits(raw_limits: str | Sequence[str] | None) -> list[str]:
-    if raw_limits is None:
-        return []
-
-    if isinstance(raw_limits, str):
-        limits: Iterable[str] = [raw_limits]
-    else:
-        limits = list(raw_limits)
-
-    return [_normalize_limit_value(limit) for limit in limits]
-
-
-limiter = Limiter(
-    key_func=get_remote_address,
-    default_limits=_normalize_limits(settings.RATE_LIMIT_DEFAULT),
-    storage_uri="redis://swimredis:6379/0",
-)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -16,7 +16,6 @@ from db import get_db
 from models import User
 from schemas import Token, RefreshRequest
 from security import create_access_token, verify_password
-from limiter import limiter
 from services.auth_sessions import issue_refresh_token, rotate_refresh_token, revoke_all_sessions
 from settings import settings
 
@@ -58,7 +57,6 @@ def _client_ip(request: Request) -> str:
 
 
 @router.post("/login", response_model=Token)
-@limiter.limit("5/minute")
 def login_token(
     request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -138,7 +136,6 @@ def auth_register_form(request: Request):
     )
 
 @router.post("/auth/register")
-@limiter.limit("5/minute")
 def auth_register(
     request: Request,
     email: str = Form(...),
@@ -203,7 +200,6 @@ def auth_login_form(request: Request):
     return request.app.state.templates.TemplateResponse("auth_login.html", {"request": request})
 
 @router.post("/auth/login")
-@limiter.limit("5/minute")
 def auth_login(
     request: Request,
     email: str = Form(...),
@@ -231,7 +227,6 @@ def auth_logout(request: Request, db: Session = Depends(get_db)):
 
 
 @router.post("/refresh", response_model=Token)
-@limiter.limit("10/minute")
 def refresh_tokens(
     request: Request,
     payload: RefreshRequest,


### PR DESCRIPTION
## Summary
- strip SlowAPI imports and middleware registration from the FastAPI app
- replace the limiter module with a no-op implementation to keep imports working
- remove limiter decorators from authentication endpoints so they continue to function without rate limits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa2d1d2f0832096701d4d7d49e0bc