### PR TITLE
Add /health FastAPI endpoint and update container healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 ## Полезные URL
 
 - Приложение: `https://localhost:8443` (или `http://localhost:8080`).
-- Промышленный health-check: `https://localhost:8443/healthz`.
+- Промышленный health-check: `https://localhost:8443/health`.
 - Метрики Prometheus: `https://localhost:8443/metrics`.
 - Почтовый стенд MailHog: `http://localhost:8025`.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -273,6 +273,7 @@ app.include_router(registrations.router, tags=["registration"])
 app.include_router(results.router, tags=["results"])
 
 
+@app.get("/health", include_in_schema=False)
 @app.get("/healthz", include_in_schema=False)
 async def healthcheck() -> Dict[str, str]:
     return {"status": "ok"}

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     LOG_DIR: str = str(BASE_DIR / "logs")
     LOG_LEVEL: str = "INFO"
     REQUEST_ID_HEADER: str = "X-Request-ID"
-    REQUEST_LOG_EXCLUDE_PATHS: tuple[str, ...] = ("/healthz",)
+    REQUEST_LOG_EXCLUDE_PATHS: tuple[str, ...] = ("/health", "/healthz")
 
     REDIS_URL: str = "redis://redis:6379/0"
     CACHE_PREFIX: str = "swimreg:cache"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     expose:
       - "8000"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/healthz || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -105,7 +105,7 @@ services:
       - ./backend/storage:/var/www/storage:ro
       - proxy_cache:/var/cache/nginx
     healthcheck:
-      test: ["CMD-SHELL", "curl -kfsS https://localhost/healthz || curl -fsS http://localhost/healthz"]
+      test: ["CMD-SHELL", "curl -kfsS https://localhost/health || curl -fsS http://localhost/health"]
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
## Summary
- add a FastAPI /health endpoint that always reports status ok and keep the legacy /healthz alias
- update request log exclusions and documentation for the new health endpoint
- point docker-compose health checks to the /health endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa7dfbf44832086cd2acb3049c4df