### PR TITLE
Install curl in backend runtime image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update \
       libpangocairo-1.0-0 \
       libgdk-pixbuf-2.0-0 \
       libffi8 \
+      curl \
  && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
## Summary
- include curl in the backend runtime image so compose health checks can run

## Testing
- ⚠️ `docker compose up --build` *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfad5bcf248320bbb275ec82abf94e