### PR TITLE
Improve docker health checks and proxy startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: up down stop logs build lint format typecheck test check install-dev
+.PHONY: up down stop logs build lint format typecheck test check install-dev open
 
 up:
-	DOCKER_BUILDKIT=1 docker compose up -d
+	DOCKER_BUILDKIT=1 docker compose up -d --build
 
 stop:
 	docker compose stop
@@ -10,7 +10,10 @@ down:
 	docker compose down
 
 logs:
-	docker compose logs -f proxy backend worker
+	docker compose logs -f backend
+
+open:
+	python3 -m webbrowser http://localhost/
 
 build:
 	DOCKER_BUILDKIT=1 docker compose build

--- a/README.md
+++ b/README.md
@@ -12,12 +12,21 @@
    ```bash
    make up
    ```
-   После старта прокси сайт будет доступен на `http://localhost:8080` (HTTPS-версия — `https://localhost:8443`).
-3. Следите за логами приложения и прокси:
+   После старта прокси сайт будет доступен на `http://localhost/` (HTTPS-версия — `https://localhost/`).
+   Приложение также отвечает напрямую по `http://localhost:8000/` — можно проверять health:
+   ```bash
+   curl -i http://localhost:8000/health
+   curl -i http://localhost:8000/ready
+   ```
+3. Откройте сайт в браузере:
+   ```bash
+   make open
+   ```
+4. Следите за логами backend:
    ```bash
    make logs
    ```
-4. Остановить или уничтожить окружение:
+5. Остановить или уничтожить окружение:
    ```bash
    make stop   # остановить контейнеры
    make down   # остановить и удалить контейнеры
@@ -46,7 +55,7 @@
 
 - Приложение запускается через `gunicorn` c воркерами `uvicorn`, дефолтное число воркеров вычисляется от числа CPU (минимум 2, максимум 8).
 - Настройки `gunicorn` лежат в `backend/gunicorn_conf.py` и могут переопределяться переменными `GUNICORN_*`.
-- На входе стоит `nginx` (см. `deploy/proxy`). Для разработки он генерирует self-signed сертификат; для продакшна достаточно смонтировать свои `tls.crt/tls.key` в `deploy/certs`.
+- На входе стоит `nginx` (см. `deploy/proxy`). Для разработки он генерирует self-signed сертификат (`dev.crt`/`dev.key`); для продакшна достаточно смонтировать свои файлы в `deploy/certs`.
 
 ## Команды разработчика
 
@@ -57,9 +66,10 @@
 
 ## Полезные URL
 
-- Приложение: `https://localhost:8443` (или `http://localhost:8080`).
-- Промышленный health-check: `https://localhost:8443/health`.
-- Метрики Prometheus: `https://localhost:8443/metrics`.
+- Приложение: `https://localhost/` (или `http://localhost/`).
+- Прямой доступ к backend: `http://localhost:8000/`.
+- Промышленный health-check: `http://localhost:8000/health` (готовность — `/ready`).
+- Метрики Prometheus: `http://localhost:8000/metrics`.
 - Почтовый стенд MailHog: `http://localhost:8025`.
 
 ## Частые вопросы

--- a/deploy/proxy/Dockerfile
+++ b/deploy/proxy/Dockerfile
@@ -1,11 +1,10 @@
 FROM nginx:1.27-alpine
 
-RUN apk add --no-cache nginx-mod-http-brotli openssl && \
+RUN apk add --no-cache nginx-mod-http-brotli openssl curl && \
     mkdir -p /etc/nginx/certs
 
-COPY docker-entrypoint.d/10-generate-cert.sh /tmp/10-generate-cert.sh
-RUN install -m 0755 /tmp/10-generate-cert.sh /docker-entrypoint.d/10-generate-cert.sh && \
-    rm /tmp/10-generate-cert.sh
+COPY docker-entrypoint.d/ /docker-entrypoint.d/
+RUN chmod +x /docker-entrypoint.d/*.sh
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY conf.d/ /etc/nginx/conf.d/
 

--- a/deploy/proxy/conf.d/app.conf
+++ b/deploy/proxy/conf.d/app.conf
@@ -18,6 +18,12 @@ server {
     client_max_body_size 25m;
     error_page 429 = @rate_limited;
 
+    location = /nginx-health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok";
+    }
+
     location /static/ {
         alias /var/www/static/;
         access_log off;
@@ -61,8 +67,8 @@ server {
     listen [::]:443 ssl http2;
     server_name _;
 
-    ssl_certificate     /etc/nginx/certs/tls.crt;
-    ssl_certificate_key /etc/nginx/certs/tls.key;
+    ssl_certificate     /etc/nginx/certs/dev.crt;
+    ssl_certificate_key /etc/nginx/certs/dev.key;
     ssl_session_cache   shared:SSL:10m;
     ssl_session_timeout 10m;
     ssl_protocols       TLSv1.2 TLSv1.3;
@@ -73,6 +79,12 @@ server {
 
     client_max_body_size 25m;
     error_page 429 = @rate_limited;
+
+    location = /nginx-health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok";
+    }
 
     location /static/ {
         alias /var/www/static/;

--- a/deploy/proxy/docker-entrypoint.d/10-generate-cert.sh
+++ b/deploy/proxy/docker-entrypoint.d/10-generate-cert.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eu
 
-CERT_DIR="/etc/nginx/certs"
-CERT_FILE="$CERT_DIR/tls.crt"
-KEY_FILE="$CERT_DIR/tls.key"
+CERT_DIR=/etc/nginx/certs
+CERT_FILE="$CERT_DIR/dev.crt"
+KEY_FILE="$CERT_DIR/dev.key"
 
 if [ "${GENERATE_DEV_CERT:-0}" = "0" ]; then
     exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,14 +59,14 @@ services:
         condition: service_started
       redis:
         condition: service_healthy
-    expose:
-      - "8000"
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
       interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 40s
+      timeout: 3s
+      retries: 10
+      start_period: 45s
     command: >-
       bash -lc "alembic -c /app/alembic.ini upgrade head && exec gunicorn -c gunicorn_conf.py --bind 0.0.0.0:8000 --worker-class uvicorn.workers.UvicornWorker app:app"
     restart: unless-stopped
@@ -100,8 +100,8 @@ services:
     environment:
       GENERATE_DEV_CERT: ${GENERATE_DEV_CERT:-1}
     ports:
-      - "${PROXY_HTTP_PORT:-8080}:80"
-      - "${PROXY_HTTPS_PORT:-8443}:443"
+      - "${PROXY_HTTP_PORT:-80}:80"
+      - "${PROXY_HTTPS_PORT:-443}:443"
     volumes:
       - ./deploy/proxy/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./deploy/proxy/conf.d:/etc/nginx/conf.d:ro
@@ -110,11 +110,11 @@ services:
       - ./backend/storage:/var/www/storage:ro
       - proxy_cache:/var/cache/nginx
     healthcheck:
-      test: ["CMD-SHELL", "curl -kfsS https://localhost/health || curl -fsS http://localhost/health"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost/nginx-health"]
       interval: 10s
-      timeout: 5s
-      retries: 12
-      start_period: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 45s
     restart: unless-stopped
 
   mailhog:


### PR DESCRIPTION
## Summary
- update the backend and proxy health checks and expose the backend on localhost:8000
- bake the nginx entrypoint scripts into the image, generate dev certificates as dev.crt/dev.key, and add a dedicated /nginx-health endpoint
- document the local URLs and add make targets for build+up, backend logs, and opening the site

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfb2f0f0408320b19a72b6b956d5f8