### PR TITLE
Fix proxy container startup without brotli module

### DIFF
--- a/deploy/proxy/Dockerfile
+++ b/deploy/proxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.27-alpine
 
-RUN apk add --no-cache nginx-mod-http-brotli openssl curl && \
+RUN apk add --no-cache openssl curl && \
     mkdir -p /etc/nginx/certs
 
 COPY docker-entrypoint.d/ /docker-entrypoint.d/

--- a/deploy/proxy/nginx.conf
+++ b/deploy/proxy/nginx.conf
@@ -4,8 +4,8 @@ worker_processes auto;
 error_log /var/log/nginx/error.log warn;
 pid       /var/run/nginx.pid;
 
-load_module modules/ngx_http_brotli_filter_module.so;
-load_module modules/ngx_http_brotli_static_module.so;
+# load_module modules/ngx_http_brotli_filter_module.so;
+# load_module modules/ngx_http_brotli_static_module.so;
 
 events {
     worker_connections 1024;
@@ -36,12 +36,21 @@ http {
     gzip_comp_level 5;
     gzip_min_length 256;
     gzip_vary on;
-    gzip_types text/plain text/css application/json application/javascript application/xml text/xml image/svg+xml;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        application/xml
+        application/json
+        application/javascript
+        application/x-javascript
+        application/rss+xml
+        image/svg+xml;
 
-    brotli on;
-    brotli_comp_level 5;
-    brotli_types text/plain text/css application/json application/javascript application/xml text/xml image/svg+xml;
-    brotli_static always;
+    # brotli on;
+    # brotli_comp_level 5;
+    # brotli_types text/plain text/css application/json application/javascript application/xml text/xml image/svg+xml;
+    # brotli_static always;
 
     proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=10m use_temp_path=off;
     proxy_cache_valid 200 301 302 10m;


### PR DESCRIPTION
## Summary
- remove the brotli module package from the proxy Docker image build
- disable brotli module loading in nginx.conf and rely on gzip compression settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb7e710748320a5fbad628ec2112e