### PR TITLE
Refine nginx proxy configuration

### DIFF
--- a/deploy/proxy/conf.d/app.conf
+++ b/deploy/proxy/conf.d/app.conf
@@ -1,129 +1,52 @@
-upstream backend_app {
-    server backend:8000;
-    keepalive 64;
+# Бэкенд
+upstream backend_upstream {
+    server swimbackend:8000 max_fails=3 fail_timeout=5s;
+    keepalive 32;
 }
 
-map $scheme $forwarded_proto {
-    default $scheme;
-}
-
+# HTTP -> HTTPS + health
 server {
     listen 80;
-    listen [::]:80;
     server_name _;
 
-    set $req_id $req_id;
-    add_header X-Request-ID $req_id;
-
-    client_max_body_size 25m;
-    error_page 429 = @rate_limited;
-
-    location = /nginx-health {
-        access_log off;
-        return 200;
-    }
-
-    location /static/ {
-        alias /var/www/static/;
-        access_log off;
-        expires 7d;
-        add_header Cache-Control "public, max-age=604800, immutable";
-        try_files $uri $uri/ =404;
-    }
-
-    location /storage/ {
-        alias /var/www/storage/;
-        access_log off;
-        expires 1h;
-        add_header Cache-Control "public, max-age=3600";
-        try_files $uri $uri/ =404;
-    }
+    # Health для оркестратора
+    location /nginx-health { return 200; }
 
     location / {
-        limit_req zone=api_rate burst=40 nodelay;
-        proxy_http_version 1.1;
-        proxy_set_header Connection "";
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $forwarded_proto;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Request-ID $req_id;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://backend_app;
-        proxy_connect_timeout 5s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
-        proxy_buffering on;
-        proxy_buffers 16 16k;
-        proxy_busy_buffers_size 24k;
-        proxy_intercept_errors on;
-        add_header Cache-Control "no-store";
+        return 301 https://$host$request_uri;
     }
 }
 
+# HTTPS сервер
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    http2 on;
+
     server_name _;
 
+    # Dev-сертификаты (предполагается, что скрипт их уже генерит сюда)
     ssl_certificate     /etc/nginx/certs/dev.crt;
     ssl_certificate_key /etc/nginx/certs/dev.key;
-    ssl_session_cache   shared:SSL:10m;
-    ssl_session_timeout 10m;
-    ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers off;
 
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-    add_header X-Request-ID $req_id;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
 
-    client_max_body_size 25m;
-    error_page 429 = @rate_limited;
+    # Health для оркестратора
+    location /nginx-health { return 200; }
 
-    location = /nginx-health {
-        access_log off;
-        return 200;
-    }
-
-    location /static/ {
-        alias /var/www/static/;
-        access_log off;
-        expires 7d;
-        add_header Cache-Control "public, max-age=604800, immutable";
-        try_files $uri $uri/ =404;
-    }
-
-    location /storage/ {
-        alias /var/www/storage/;
-        access_log off;
-        expires 1h;
-        add_header Cache-Control "public, max-age=3600";
-        try_files $uri $uri/ =404;
-    }
-
+    # Проксирование на backend
     location / {
-        limit_req zone=api_rate burst=40 nodelay;
+        proxy_pass http://backend_upstream;
+
         proxy_http_version 1.1;
         proxy_set_header Connection "";
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Request-ID $req_id;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://backend_app;
-        proxy_connect_timeout 5s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
-        proxy_buffering on;
-        proxy_buffers 16 16k;
-        proxy_busy_buffers_size 24k;
-        proxy_intercept_errors on;
-        add_header Cache-Control "no-store";
-    }
-}
 
-location @rate_limited {
-    internal;
-    default_type application/json;
-    return 429 '{"detail":"Too Many Requests"}';
+        proxy_set_header Host               $host;
+        proxy_set_header X-Real-IP          $remote_addr;
+        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto  $scheme;
+
+        proxy_read_timeout  60s;
+        proxy_send_timeout  60s;
+    }
 }

--- a/deploy/proxy/nginx.conf
+++ b/deploy/proxy/nginx.conf
@@ -1,37 +1,32 @@
 user  nginx;
 worker_processes auto;
 
-error_log /var/log/nginx/error.log warn;
-pid       /var/run/nginx.pid;
-
-# load_module modules/ngx_http_brotli_filter_module.so;
-# load_module modules/ngx_http_brotli_static_module.so;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
 
 events {
-    worker_connections 1024;
-    multi_accept on;
+    worker_connections  1024;
+    multi_accept        on;
 }
 
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    map $http_x_request_id $req_id {
-        default $http_x_request_id;
-        "" $request_id;
-    }
-
-    log_format json_combined escape=json '{"timestamp":"$time_iso8601","remote_addr":"$remote_addr","request":"$request","status":$status,"body_bytes_sent":$body_bytes_sent,"request_time":$request_time,"request_id":"$req_id"}';
-    access_log /var/log/nginx/access.log json_combined;
-
     sendfile        on;
     tcp_nopush      on;
     tcp_nodelay     on;
-    keepalive_timeout 65;
-    keepalive_requests 1000;
-    types_hash_max_size 4096;
-    server_tokens off;
 
+    keepalive_timeout  65;
+
+    # Логи
+    access_log  /var/log/nginx/access.log  main;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    # Сжатие gzip (без brotli)
     gzip on;
     gzip_comp_level 5;
     gzip_min_length 256;
@@ -39,25 +34,12 @@ http {
     gzip_types
         text/plain
         text/css
-        text/xml
-        application/xml
         application/json
         application/javascript
-        application/x-javascript
+        application/xml
         application/rss+xml
         image/svg+xml;
 
-    # brotli on;
-    # brotli_comp_level 5;
-    # brotli_types text/plain text/css application/json application/javascript application/xml text/xml image/svg+xml;
-    # brotli_static always;
-
-    proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=10m use_temp_path=off;
-    proxy_cache_valid 200 301 302 10m;
-    proxy_temp_path /var/cache/nginx/tmp;
-
-    limit_req_zone $binary_remote_addr zone=api_rate:10m rate=20r/s;
-    limit_req_status 429;
-
+    # Конфиги виртуальных хостов
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary
- replace the bundled nginx.conf with a minimal, self-contained configuration focused on gzip and logging
- rebuild app.conf to serve HTTP->HTTPS redirects, expose /nginx-health, and proxy backend traffic with HTTP/2 and upstream keepalive settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfbab80a588320a4d76a7a931032c2