### PR TITLE
Enable default dev cert generation for proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       backend:
         condition: service_healthy
     environment:
-      GENERATE_DEV_CERT: "0"
+      GENERATE_DEV_CERT: "${GENERATE_DEV_CERT:-1}"
     ports:
       - "${PROXY_HTTP_PORT:-80}:80"
       - "${PROXY_HTTPS_PORT:-443}:443"


### PR DESCRIPTION
## Summary
- default the proxy container to generate a development TLS certificate when the control variable is unset

## Testing
- not run (docker is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfc08c549c8320b96127ecac57a676